### PR TITLE
Fix 504 errors for crawlers

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -15,6 +15,6 @@
         RewriteCond %{QUERY_STRING} _escaped_fragment_
         RewriteCond %{REQUEST_URI} ^(?!.*?(\.js|\.css|\.xml|\.less|\.png|\.jpg|\.jpeg|\.gif|\.pdf|\.doc|\.txt|\.ico|\.rss|\.zip|\.mp3|\.rar|\.exe|\.wmv|\.doc|\.avi|\.ppt|\.mpg|\.mpeg|\.tif|\.wav|\.mov|\.psd|\.ai|\.xls|\.mp4|\.m4a|\.swf|\.dat|\.dmg|\.iso|\.flv|\.m4v|\.torrent|\.ttf|\.woff|\.svg))
 
-        RewriteRule ^(index\.html|index\.php)?(.*) https://service.prerender.io/%{REQUEST_SCHEME}://%{HTTP_HOST}$2 [P,END]
+        RewriteRule ^(index\.html|index\.php)?(.*) https://service.prerender.io/%{REQUEST_SCHEME}://%{HTTP_HOST}/$2 [P,END]
     </IfModule>
 </IfModule>

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Here is the actual config that sends the request to Prerender.io:
         RewriteCond %{QUERY_STRING} _escaped_fragment_
         RewriteCond %{REQUEST_URI} ^(?!.*?(\.js|\.css|\.xml|\.less|\.png|\.jpg|\.jpeg|\.gif|\.pdf|\.doc|\.txt|\.ico|\.rss|\.zip|\.mp3|\.rar|\.exe|\.wmv|\.doc|\.avi|\.ppt|\.mpg|\.mpeg|\.tif|\.wav|\.mov|\.psd|\.ai|\.xls|\.mp4|\.m4a|\.swf|\.dat|\.dmg|\.iso|\.flv|\.m4v|\.torrent|\.ttf|\.woff|\.svg))
 
-        RewriteRule ^(index\.html|index\.php)?(.*) https://service.prerender.io/%{REQUEST_SCHEME}://%{HTTP_HOST}$2 [P,END]
+        RewriteRule ^(index\.html|index\.php)?(.*) https://service.prerender.io/%{REQUEST_SCHEME}://%{HTTP_HOST}/$2 [P,END]
     </IfModule>
 </IfModule>
 ```


### PR DESCRIPTION
When crawlers try to index a folder on a website, say `example.com/folder`, Prerender is trying to fetch `example.comfolder` instead, thus giving a 504 to the bot. Adding a / between %{HTTP_HOST} and $2 in the .htaccess fixes that.

Real life example:
![image](https://user-images.githubusercontent.com/2225711/195848652-c4ec4f62-5e47-40c4-b2d3-5c8b306941ad.png)
Last 2 are before the fix, first 2 are after the fix.